### PR TITLE
Adding missing translations in Core [en]

### DIFF
--- a/Resources/translations/security.en.xlf
+++ b/Resources/translations/security.en.xlf
@@ -62,6 +62,22 @@
                 <source>Account is locked.</source>
                 <target>Account is locked.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Bad credentials.</source>
+                <target>Bad credentials.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>The credentials were changed from another session.</source>
+                <target>The credentials were changed from another session.</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>The presented password cannot be empty.</source>
+                <target>The presented password cannot be empty.</target>
+            </trans-unit>
+            <trans-unit id="20">
+                <source>The presented password is invalid.</source>
+                <target>The presented password is invalid.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
Issue: https://github.com/symfony/symfony/issues/25300

This is for "en" only so not a biggie at all, all other languages still need to be done.