### PR TITLE
Remove unnecessary `inherited doc` annotation

### DIFF
--- a/User/User.php
+++ b/User/User.php
@@ -82,33 +82,21 @@ final class User implements UserInterface, EquatableInterface
         return $this->username;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function isAccountNonExpired(): bool
     {
         return $this->accountNonExpired;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function isAccountNonLocked(): bool
     {
         return $this->accountNonLocked;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function isCredentialsNonExpired(): bool
     {
         return $this->credentialsNonExpired;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function isEnabled(): bool
     {
         return $this->enabled;


### PR DESCRIPTION
Removes unnecessary `inherited doc` annotation from php doc from the methods that are not inherited from any parent class/interface.