### PR TITLE
Support Uuid/Ulid as userIdentifier in hasUserChanged()

### DIFF
--- a/Authentication/Token/AbstractToken.php
+++ b/Authentication/Token/AbstractToken.php
@@ -309,7 +309,14 @@ abstract class AbstractToken implements TokenInterface
         $userIdentifier = function ($user) {
             return method_exists($user, 'getUserIdentifier') ? $user->getUserIdentifier() : $user->getUsername();
         };
-        if ($userIdentifier($this->user) !== $userIdentifier($user)) {
+        // if the username/identifier is an object with an eqials-method (like Uuid or Ulid), prefer that for a comparison
+        if (is_object($userIdentifier($this->user)) && method_exists($userIdentifier($this->user), 'equals')) {
+            if (!$userIdentifier($this->user)->equals($userIdentifier($user))){
+                return true;
+            }
+        }
+        // otherwise assume a scalar identifier and do a strict comparison
+        elseif ($userIdentifier($this->user) !== $userIdentifier($user)) {
             return true;
         }
 


### PR DESCRIPTION
Uuid/Ulid are supported as Doctrine types since Symfony 5.2, but when a User Entity uses them as its identifier, the strict comparison of the identifier in AbstractToken::hasUserChanged() fails unless the User Entity implements EquatableInterface and does the whole comparison itself. In effect, the user is always assumed as changed and logged out.

This change implements a check, if the `getUserIdentifier()` method of the User Entity returns an object with an `equals` method and uses that for the comparison instead of the strict `!==` operator, that is always true for two different Uuid/Ulid objects, even if they contain the same uid.