### PR TITLE
“username” was renamed “user identifier”

### DIFF
--- a/User/InMemoryUserProvider.php
+++ b/User/InMemoryUserProvider.php
@@ -56,7 +56,7 @@ class InMemoryUserProvider implements UserProviderInterface
     {
         $userIdentifier = strtolower($user->getUserIdentifier());
         if (isset($this->users[$userIdentifier])) {
-            throw new \LogicException('Another user with the same username already exists.');
+            throw new \LogicException('Another user with the same identifier already exists.');
         }
 
         $this->users[$userIdentifier] = $user;


### PR DESCRIPTION
In Symfony 5.3   to avoid confusion “username” was renamed “user identifier”