### PR TITLE
Update TraceableAccessDecisionManager.php

### DIFF
--- a/Authorization/TraceableAccessDecisionManager.php
+++ b/Authorization/TraceableAccessDecisionManager.php
@@ -36,13 +36,11 @@ class TraceableAccessDecisionManager implements AccessDecisionManagerInterface
     {
         $this->manager = $manager;
 
-        if ($this->manager instanceof AccessDecisionManager) {
-            // The strategy and voters are stored in a private properties of the decorated service
-            $reflection = new \ReflectionProperty(AccessDecisionManager::class, 'strategy');
-            $this->strategy = $reflection->getValue($manager);
-            $reflection = new \ReflectionProperty(AccessDecisionManager::class, 'voters');
-            $this->voters = $reflection->getValue($manager);
-        }
+        $reflection = new \ReflectionProperty(get_class($manager), 'strategy');
+        $this->strategy = $reflection->getValue($manager);
+        $reflection = new \ReflectionProperty(get_class($manager), 'voters');
+        $this->voters = $reflection->getValue($manager);
+        
     }
 
     /**


### PR DESCRIPTION
Removed the "if" statement that verifies if the ADM is instance of AccessDecisionManager.

This control breaks profiler when it is trying to browse "Security" tab while a custom ADM was developed. The reason is that the "if" statement prevents SecurityDataCollector.php to retrieve the strategy and the list of voters.

Based on my tests this modification doesn't affect the regular functionality of security-core.